### PR TITLE
feat: agregar carpeta de migraciones con env.py y script.py.mako

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,100 @@
+import os
+import sys
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+# Agregar el directorio raíz al path para importar los modelos
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+# Importar los modelos para que Alembic los detecte
+from database.config import Base
+from entities.Biblioteca import Biblioteca
+from entities.Categoria import Categoria
+from entities.Cliente import Cliente
+from entities.Material_Bibliografico import Material_Bibliografico
+from entities.Prestamo import Prestamo
+from entities.Reserva import Reserva
+from entities.Sancion import Sancion
+from entities.Sede import Sede
+from entities.Usuario import Usuario
+
+# this is the Alembic Config object, which provides
+# access t
+# o the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+target_metadata = Base.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def get_url():
+    """Obtener la URL de la base de datos desde variables de entorno"""
+    from database.config import DATABASE_URL
+
+    return DATABASE_URL
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = get_url()
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    configuration = config.get_section(config.config_ini_section)
+    configuration["sqlalchemy.url"] = get_url()
+
+    connectable = engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}


### PR DESCRIPTION
Este Pull Request agrega la carpeta `migraciones` que contiene los archivos necesarios para la gestión de migraciones de la base de datos:

- `env.py` → configuración del entorno de migración.
- `script.py.mako` → plantilla para generación de scripts de migración.
